### PR TITLE
run.spec.cpp call_run lambda return type

### DIFF
--- a/specs/run.spec.cpp
+++ b/specs/run.spec.cpp
@@ -11,7 +11,7 @@ go_bandit([](){
     fake_reporter_ptr reporter;
     std::unique_ptr<bd::contextstack_t> context_stack;
 
-    auto call_run = [&](){
+    auto call_run = [&]() -> int {
         bd::options opt(argv->argc(), argv->argv());
         return bandit::run(opt, *specs, *context_stack, *reporter);
     };


### PR DESCRIPTION
I was getting
~~~
specs/run.spec.cpp:14:21: error: C++11 requires lambda with omitted result
type to consist of a single return statement [-Werror,-Wlambda-extensions]
    auto call_run = [&](){
                    ^
1 error generated.
~~~
solved by declare the lambda return type