### PR TITLE
Fix failure messages from MatcherException.

### DIFF
--- a/bandit/assertion_frameworks/matchers/MatcherException.h
+++ b/bandit/assertion_frameworks/matchers/MatcherException.h
@@ -1,22 +1,15 @@
 #ifndef BANDIT_MATCHER_EXCEPTION_H
 #define BANDIT_MATCHER_EXCEPTION_H
 
+#include <bandit/assertion_exception.h>
+
 namespace bandit { namespace Matchers {
-    class MatcherException : public std::exception
+    class MatcherException : public detail::assertion_exception
     {
     public:
-      MatcherException(const std::string& filename, const unsigned linenumber, const std::string& message) : _filename(filename), _linenumber(linenumber), _message(message) {}
+      MatcherException(const std::string& filename, const unsigned linenumber, const std::string& message) : detail::assertion_exception(message, filename, linenumber) {}
       MatcherException(const MatcherException&) = default;
       virtual ~MatcherException() noexcept {}
-
-	std::string& filename()	{ return _message; }
-	unsigned linenumber()	{ return _linenumber; }
-	std::string& message()	{ return _message; }
-
-    private:
-	std::string	_filename;
-	unsigned	_linenumber;
-	std::string	_message;
     };
 }}
 


### PR DESCRIPTION
Hi.

This patch fixes failure messages from ```bandit::Matchers``` by make ```MatchersException``` inherit ```assertion_exception```.

For example, without this patch, the failure message from this code 
``` c++
#include <bandit/bandit.h>
using namespace bandit;
using namespace bandit::Matchers;

go_bandit([]() {
  describe("1 and 2", []() {
    it("should be equal", []() { 1 must equal(2); });
  });
});
```
goes like
```
1 and 2 should be equal:
exception: std::exception
```
and with this patch, it goes like
```
1 and 2 should be equal:
foo.cc:26: Expected <1> to equal <2>
```