### PR TITLE
Avoid implicit conversion from nullptr_t to bool.

### DIFF
--- a/bandit/assertion_frameworks/matchers/BeFalsy.h
+++ b/bandit/assertion_frameworks/matchers/BeFalsy.h
@@ -20,6 +20,11 @@ namespace bandit { namespace Matchers {
 	    return !actualValue;
 	}
 
+        bool matches(const std::nullptr_t& actualValue) const
+	{
+	    return true;
+	}
+
 
     protected:
         virtual std::string failure_message_end() const

--- a/bandit/assertion_frameworks/matchers/BeTruthy.h
+++ b/bandit/assertion_frameworks/matchers/BeTruthy.h
@@ -16,6 +16,11 @@ namespace bandit { namespace Matchers {
 	    return !!actualValue;
 	}
 
+        bool matches(const std::nullptr_t& actualValue) const
+	{
+	    return false;
+	}
+
 
     protected:
         virtual std::string failure_message_end() const


### PR DESCRIPTION
This patch suprress the warning from gcc-5+ and clang-3.6+ about implicit conversion from ```nullptr_t``` to ```bool```.