### PR TITLE
Fixed a missing STL include in Contain.h

### DIFF
--- a/bandit/assertion_frameworks/matchers/Contain.h
+++ b/bandit/assertion_frameworks/matchers/Contain.h
@@ -2,6 +2,7 @@
 #define BANDIT_CONTAIN_H
 
 #include <cstring>
+#include <vector>
 
 #include "Matcher.h"
 


### PR DESCRIPTION
std::vector doesn’t work without #include \<vector\>
