### PR TITLE
fix(windows): prevent redefinition of NOMINMAX

### DIFF
--- a/bandit/reporters/colorizer.h
+++ b/bandit/reporters/colorizer.h
@@ -2,7 +2,7 @@
 #define BANDIT_REPORTERS_COLORIZER_H
 
 #ifdef _WIN32
-  #ifndef MINGW32
+  #ifndef NOMINMAX
     #define NOMINMAX
   #endif
 


### PR DESCRIPTION
Check for (not) defined NOMINMAX rather than MINGW32
Adresses https://github.com/joakimkarlsson/bandit/issues/19

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/joakimkarlsson/bandit/55)
<!-- Reviewable:end -->
