### PR TITLE
Fix unused-parameter and missing-field-initializers warnings

### DIFF
--- a/bandit/assertion_frameworks/matchers/BeFalsy.h
+++ b/bandit/assertion_frameworks/matchers/BeFalsy.h
@@ -20,7 +20,7 @@ namespace bandit { namespace Matchers {
 	    return !actualValue;
 	}
 
-        bool matches(const std::nullptr_t& actualValue) const
+        bool matches(const std::nullptr_t&) const
 	{
 	    return true;
 	}

--- a/bandit/assertion_frameworks/matchers/BeTruthy.h
+++ b/bandit/assertion_frameworks/matchers/BeTruthy.h
@@ -16,7 +16,7 @@ namespace bandit { namespace Matchers {
 	    return !!actualValue;
 	}
 
-        bool matches(const std::nullptr_t& actualValue) const
+        bool matches(const std::nullptr_t&) const
 	{
 	    return false;
 	}

--- a/bandit/reporters/colorizer.h
+++ b/bandit/reporters/colorizer.h
@@ -79,7 +79,7 @@ namespace bandit { namespace detail {
   private:
 	  WORD get_console_color() const
 	  {
-		  CONSOLE_SCREEN_BUFFER_INFO info = {0};
+		  CONSOLE_SCREEN_BUFFER_INFO info{};
 		  GetConsoleScreenBufferInfo(stdout_handle_, &info);
 		  return info.wAttributes;
 	  }


### PR DESCRIPTION
Checked with GCC 5.1.0 under Windows