### PR TITLE
Fixed MSVC compiler error on defaulted move constructor

### DIFF
--- a/bandit/assertion_exception.h
+++ b/bandit/assertion_exception.h
@@ -18,7 +18,17 @@ namespace bandit { namespace detail {
     // To make gcc < 4.7 happy.
     //
     assertion_exception(const assertion_exception&) = default;
+
+#ifndef _MSC_VER
     assertion_exception(assertion_exception&&) = default;
+#else
+	assertion_exception(assertion_exception&& other)
+		: std::runtime_error(other), file_name_(), line_number_(other.line_number_)
+	{
+		std::swap(file_name_, other.file_name_);
+	}
+#endif
+
     virtual ~assertion_exception() noexcept
     {}
 

--- a/bandit/run_policies/run_policy.h
+++ b/bandit/run_policies/run_policy.h
@@ -7,7 +7,13 @@ namespace bandit { namespace detail {
   {
     run_policy() : encountered_failure_(false) {}
     run_policy(const run_policy& other) = default;
+
+#ifndef _MSC_VER
     run_policy(run_policy&&) = default;
+#else
+	run_policy(run_policy&& other) : encountered_failure_(other.encountered_failure_) {}
+#endif
+
     virtual ~run_policy() {}
 
     virtual bool should_run(const char* it_name, const contextstack_t& contexts) const = 0;


### PR DESCRIPTION
MSVC has not support for defaulted move constructors or move-assignment operators.
https://msdn.microsoft.com/en-us/library/dn457344.aspx