### PR TITLE
Separating registration of from access to registered values

### DIFF
--- a/bandit/reporters/reporters.h
+++ b/bandit/reporters/reporters.h
@@ -12,17 +12,41 @@
 
 namespace bandit { namespace detail {
 
-  inline listener& registered_listener(listener* reporter = NULL)
-  {
-    static struct listener* reporter_;
+struct listener;
 
-    if(reporter)
-    {
-      reporter_ = reporter;
+struct reporter {
+  // A function is required to initialize a static listener variable in a header file
+  // and this struct aims at encapsulating this function
+  static void register_listener(listener *reporter) {
+    if(reporter == nullptr) {
+      throw std::runtime_error("Invalid null reporter passed to "
+        "bandit::detail::register_listener");
     }
-
-    return *reporter_;
+    get_reporter_address() = reporter;
   }
+  static listener& registered_listener() {
+    auto reporter = get_reporter_address();
+    if(reporter == nullptr) {
+      throw std::runtime_error("No reporter set. Please call "
+        "bandit::detail::register_listener with a non-null reporter");
+    }
+    return *reporter;
+  }
+private:
+  static listener*& get_reporter_address() {
+    static listener* reporter_ = nullptr;
+    return reporter_;
+  }
+};
+
+inline void register_listener(listener *reporter)
+{
+  reporter::register_listener(reporter);
+}
+inline listener& registered_listener()
+{
+  return reporter::registered_listener();
+}
 
 }}
 

--- a/bandit/run_policies/run_policy.h
+++ b/bandit/run_policies/run_policy.h
@@ -33,18 +33,34 @@ namespace bandit { namespace detail {
   };
   typedef std::unique_ptr<run_policy> run_policy_ptr;
 
-  inline run_policy& registered_run_policy(run_policy* policy = NULL)
+  struct policy_runner
   {
-    static struct run_policy* policy_;
-
-    if(policy)
-    {
-      policy_ = policy;
+    // A function is required to initialize a static run_policy variable in a header file
+    // and this struct aims at encapsulating this function
+    static void register_run_policy(run_policy* policy) {
+      if(policy == nullptr) {
+        throw std::runtime_error("Invalid null policy passed to "
+          "bandit::detail::register_run_policy");
+      }
+      get_run_policy_address() = policy;
     }
-
-    return *policy_;
-  }
-
+    static run_policy& registered_run_policy()
+    {
+      auto policy = get_run_policy_address();
+      if(policy == nullptr) {
+        throw std::runtime_error("No policy set. Please call "
+          "bandit::detail::register_run_policy with a non-null reporter");
+      }
+      return *policy;
+    }
+  private:
+    static run_policy*& get_run_policy_address() {
+      static run_policy* policy = nullptr;
+      return policy;
+    }
+  };
+  inline void register_run_policy(run_policy* policy) {policy_runner::register_run_policy(policy);}
+  inline run_policy& registered_run_policy() {return policy_runner::registered_run_policy();}
 }}
 
 #endif

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -94,7 +94,7 @@ namespace bandit {
     detail::register_listener(reporter.get());
 
     detail::run_policy_ptr run_policy = create_run_policy(opt);
-    registered_run_policy(run_policy.get());
+    register_run_policy(run_policy.get());
 
     return run(opt, detail::specs(), detail::context_stack(), *reporter);
   }

--- a/bandit/runner.h
+++ b/bandit/runner.h
@@ -91,7 +91,7 @@ namespace bandit {
     bandit::detail::colorizer colorizer(!opt.no_color());
     detail::listener_ptr reporter(create_reporter(opt, formatter.get(), colorizer));
 
-    detail::registered_listener(reporter.get());
+    detail::register_listener(reporter.get());
 
     detail::run_policy_ptr run_policy = create_run_policy(opt);
     registered_run_policy(run_policy.get());


### PR DESCRIPTION
Hi guys,

I am currently looking for different unit test tools and bandit seems a very interesting choice!
However, when running clang-tidy on a minimal project, I get some warnings and I do not want any warning (as I set an option so that they automatically trigger errors)...

These warnings are related to the registration and access to registered values contained in a single function for run_policy and listener (it is a bit tricky to initialise static variables in header files...). The two commits of this pull request fix these warnings and, in my opinion, improve a bit the design as the registration and the access to the variables are now in two different functions and enable to test if they have been registered before being retrieved (but there is more code because of the initialisation of the static variables...).

Please let me know what your thoughts are! And do not hesitate to ask me to do some changes so that the code I wrote is more consistent with the rest of the code (I only guessed the style from a few snippets I could see).

Kind regards,

Marc-Olivier

PS: I have run travis on my branch and it seems to pass.
PS: the small file generating the errors was based on the second example of http://banditcpp.org/writingtests.html:
```c++
#include <bandit/bandit.h>

// Tell bandit there are tests here.
go_bandit([](){
  bandit::describe("our first test", [](){
    bandit::it("should fail", [&](){
      AssertThat(6, Equals(6));
    });
  });
});

int main(int argc, char* argv[])
{
  // Run the tests.
  return bandit::run(argc, argv);
} 
```

PS: And if you want more info to install/run clang-tidy, do not hesitate to contact me.